### PR TITLE
Refresh Delay, Download Limit

### DIFF
--- a/wget/wget.go
+++ b/wget/wget.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/laher/uggo"
 	"io"
 	"math"
 	"mime"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/laher/uggo"
 )
 
 //TODO
@@ -32,31 +33,33 @@ import (
 // timestamping
 // wgetrc
 type Wgetter struct {
-	IsContinue     bool
+	IsContinue bool
 	// should be set explicitly to false when running from CLI. uggo will detect as best as possible
-	AlwaysPipeStdin   bool 
-	OutputFilename string
-	Timeout        int //TODO
-	Retries        int //TODO
-	IsVerbose      bool //todo
-	DefaultPage    string
-	UserAgent      string //todo
-	ProxyUser	string //todo
-	ProxyPassword	string //todo
-	Referer		string //todo
-	SaveHeaders	bool //todo
-	PostData	string //todo
-	HttpUser	string //todo
-	HttpPassword    string //todo
+	AlwaysPipeStdin      bool
+	OutputFilename       string
+	Timeout              int  //TODO
+	Retries              int  //TODO
+	IsVerbose            bool //todo
+	DefaultPage          string
+	UserAgent            string //todo
+	ProxyUser            string //todo
+	ProxyPassword        string //todo
+	Referer              string //todo
+	SaveHeaders          bool   //todo
+	PostData             string //todo
+	HttpUser             string //todo
+	HttpPassword         string //todo
 	IsNoCheckCertificate bool
-	SecureProtocol string
+	SecureProtocol       string
 
 	links []string
 }
 
 const (
-	VERSION              = "0.5.0"
-	FILEMODE os.FileMode = 0660
+	VERSION                     = "0.5.0"
+	FILEMODE        os.FileMode = 0660
+	WGET_DISP_DELAY             = int64(100)
+	NANO_TO_MILLI               = int64(1000000) // Magic numbers are bad, mmkay
 )
 
 //Factory for wgetter which outputs to Stdout
@@ -94,13 +97,14 @@ func WgetCli(call []string) (error, int) {
 func (tail *Wgetter) Name() string {
 	return "wget"
 }
+
 // Parse CLI flags
 func (w *Wgetter) ParseFlags(call []string, errPipe io.Writer) (error, int) {
 
 	flagSet := uggo.NewFlagSetDefault("wget", "[options] URL", VERSION)
 	flagSet.SetOutput(errPipe)
 	flagSet.AliasedBoolVar(&w.IsContinue, []string{"c", "continue"}, false, "continue")
-	flagSet.AliasedStringVar(&w.OutputFilename, []string{"O","output-document"}, "", "specify filename")
+	flagSet.AliasedStringVar(&w.OutputFilename, []string{"O", "output-document"}, "", "specify filename")
 	flagSet.StringVar(&w.DefaultPage, "default-page", "index.html", "default page name")
 	flagSet.BoolVar(&w.IsNoCheckCertificate, "no-check-certificate", false, "skip certificate checks")
 
@@ -144,24 +148,24 @@ func (w *Wgetter) Exec(inPipe io.Reader, outPipe io.Writer, errPipe io.Writer) (
 			}
 		}
 	} else {
-			bio := bufio.NewReader(inPipe)
-			hasMoreInLine := true
-			var err error
-			var line []byte
-			for hasMoreInLine {
-				line, hasMoreInLine, err = bio.ReadLine()
-				if err == nil {
-					//line from stdin
-					err = wgetOne(strings.TrimSpace(string(line)), w, outPipe, errPipe)
+		bio := bufio.NewReader(inPipe)
+		hasMoreInLine := true
+		var err error
+		var line []byte
+		for hasMoreInLine {
+			line, hasMoreInLine, err = bio.ReadLine()
+			if err == nil {
+				//line from stdin
+				err = wgetOne(strings.TrimSpace(string(line)), w, outPipe, errPipe)
 
-					if err != nil {
-						return err, 1
-					}
-				} else {
-					//finish
-					hasMoreInLine = false
+				if err != nil {
+					return err, 1
 				}
+			} else {
+				//finish
+				hasMoreInLine = false
 			}
+		}
 
 	}
 	return nil, 0
@@ -261,7 +265,7 @@ func wgetOne(link string, options *Wgetter, outPipe io.Writer, errPipe io.Writer
 	lenS := resp.Header.Get("Content-Length")
 	length := int64(-1)
 	if lenS != "" {
-		length, err = strconv.ParseInt(lenS, 10, 32)
+		length, err = strconv.ParseInt(lenS, 10, 64)
 		if err != nil {
 			return err
 		}
@@ -308,7 +312,7 @@ func wgetOne(link string, options *Wgetter, outPipe io.Writer, errPipe io.Writer
 	buf := make([]byte, 4068)
 	tot := int64(0)
 	i := 0
-
+	sinceLast := time.Now()
 	for {
 		// read a chunk
 		n, err := resp.Body.Read(buf)
@@ -324,11 +328,11 @@ func wgetOne(link string, options *Wgetter, outPipe io.Writer, errPipe io.Writer
 		if _, err := out.Write(buf[:n]); err != nil {
 			return err
 		}
-		i += 1
+		i++
 		if length > -1 {
 			if length < 1 {
 				fmt.Fprintf(errPipe, "\r     [ <=>                                  ] %d\t-.--KB/s eta ?s             ", tot)
-			} else {
+			} else if (time.Now().Sub(sinceLast).Nanoseconds() / NANO_TO_MILLI) > WGET_DISP_DELAY {
 				//show percentage
 				perc := (100 * tot) / length
 				prog := progress(perc)
@@ -338,6 +342,7 @@ func wgetOne(link string, options *Wgetter, outPipe io.Writer, errPipe io.Writer
 				remKb := float64(length-tot) / float64(1000)
 				eta := remKb / spd
 				fmt.Fprintf(errPipe, "\r%3d%% [%s] %d\t%0.2fKB/s eta %0.1fs             ", perc, prog, tot, spd, eta)
+				sinceLast = time.Now()
 			}
 		} else {
 			//show dots


### PR DESCRIPTION
- Added a refresh delay that increased throughput elevenfold - faster than native wget!
- Fixed bug that limited file sizes to 2^31-1 bytes
- Formatting changes "helpfully" suggested by VS Code